### PR TITLE
RLBench dataset-generator command updated in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ See [quickstart guide](#quickstart) on how to evaluate these checkpoints. Make s
 
 ## Data Generation
 
-Data generation is pretty similar to the [ARM setup](https://github.com/stepjam/RLBench), except you use `--all_variations=True` to sample all task variations:
+Data generation is pretty similar to the [ARM setup](https://github.com/stepjam/RLBench), except you use `--variations=-1` to sample all task variations:
 
 ```bash
 cd <install_dir>/RLBench/tools
@@ -223,7 +223,7 @@ python dataset_generator.py --tasks=open_drawer \
                             --renderer=opengl \
                             --episodes_per_task=100 \
                             --processes=1 \
-                            --all_variations=True
+                            --variations=-1
 ```
 
 You can run these in parallel for multiple tasks. Here is a list of 18 tasks used in the paper (in the same order as results Table 1):

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ python dataset_generator.py --tasks=open_drawer \
                             --renderer=opengl \
                             --episodes_per_task=10 \
                             --processes=1 \
-                            --all_variations=True
+                            --variations=-1
 ```
 This will take a few minutes to finish.
 


### PR DESCRIPTION
RLBench dataset-generator.py command updated to match RLBench tools script:

New:
python dataset_generator.py --tasks=open_drawer \
                            --save_path=$PERACT_ROOT/data/val \
                            --image_size=128,128 \
                            --renderer=opengl \
                            --episodes_per_task=10 \
                            --processes=1 \
                            --variations=-1

Old:
python dataset_generator.py --tasks=open_drawer \
                            --save_path=$PERACT_ROOT/data/val \
                            --image_size=128,128 \
                            --renderer=opengl \
                            --episodes_per_task=10 \
                            --processes=1 \
                            --all_variations=True